### PR TITLE
Migrate to Keystone API V3

### DIFF
--- a/lib/OVHStorage.js
+++ b/lib/OVHStorage.js
@@ -29,16 +29,26 @@ class OVHStorage {
 
     var json = {
       auth: {
-        passwordCredentials: {
-          username: this.config.username,
-          password: this.config.password
-        },
-        tenantId: this.config.tenantId
+        identity: {
+          methods: [
+            "password"
+          ],
+          password: {
+            user: {
+              name: this.config.username,
+              domain: {
+                name: "Default"
+              },
+              password: this.config.password
+            }
+          },
+          tenantId: this.config.tenantId
+        }
       }
     };
     request({
       method:   'POST',
-      uri:      this.config.authURL + '/tokens',
+      uri:      this.config.authURL + '/auth/tokens',
       json:     json,
       headers:  { 'Accept': 'application/json' },
       encoding: null
@@ -51,8 +61,8 @@ class OVHStorage {
         return callback(body.error.message);
       }
 
-      var token           = body.access.token;
-      var serviceCatalog  = _.find(body.access.serviceCatalog, { type: 'object-store' });
+      var token           = res.headers['x-subject-token'];
+      var serviceCatalog  = _.find(body.token.catalog, { type: 'object-store' });
       var endpoint        = _.find(serviceCatalog.endpoints, { region: _this.config.region });
 
       if (!endpoint) {
@@ -77,13 +87,13 @@ class OVHStorage {
    */
   getFileList(folderPath, callback) {
     var _this     = this;
-    var targetURL = this.endpoint.publicURL + folderPath;
+    var targetURL = this.endpoint.url + folderPath;
     request({
       method:   'GET',
       uri:      targetURL,
       json:     true,
       headers:  {
-        "X-Auth-Token": this.token.id,
+        "X-Auth-Token": this.token,
         "Accept": "application/json"
       }
     }, function (err, res, body) {
@@ -103,13 +113,13 @@ class OVHStorage {
    */
   getFile(path, callback) {
     var _this     = this;
-    var targetURL = this.endpoint.publicURL + path;
+    var targetURL = this.endpoint.url + path;
     request({
       method:   'GET',
       uri:      targetURL,
       encoding: null,
       headers:  {
-        "X-Auth-Token": this.token.id,
+        "X-Auth-Token": this.token,
         "Accept": "application/json"
       }
     }, function (err, res, body) {
@@ -140,7 +150,7 @@ class OVHStorage {
   // PUT /path : upload file
   putStream(stream, path, headers, callback) {
     var _this     = this;
-    var targetURL = this.endpoint.publicURL + path;
+    var targetURL = this.endpoint.url + path;
 
     if (_.isFunction(headers)) {
       callback  = headers;
@@ -149,7 +159,7 @@ class OVHStorage {
     headers = headers || {};
 
     Object.assign(headers, {
-      "X-Auth-Token": this.token.id,
+      "X-Auth-Token": this.token,
       "Accept": "application/json"
     });
 
@@ -170,7 +180,7 @@ class OVHStorage {
   // DELETE /path : delete file
   deleteFile(path, headers, callback) {
     var _this     = this;
-    var targetURL = this.endpoint.publicURL + path;
+    var targetURL = this.endpoint.url + path;
 
     if (_.isFunction(headers)) {
       callback  = headers;
@@ -179,7 +189,7 @@ class OVHStorage {
     headers = headers || {};
 
     Object.assign(headers, {
-      "X-Auth-Token": this.token.id,
+      "X-Auth-Token": this.token,
       "Accept": "application/json"
     });
 
@@ -200,14 +210,14 @@ class OVHStorage {
   //
   createContainer(container, callback) {
     var _this = this;
-    var targetURL = this.endpoint.publicURL + '/' + container;
+    var targetURL = this.endpoint.url + '/' + container;
 
     request({
       method:   'PUT',
       uri:      targetURL,
       encoding: null,
       headers: {
-        "X-Auth-Token": _this.token.id,
+        "X-Auth-Token": _this.token,
         "Accept":       "application/json"
       }
     }, function (err, res, body) {


### PR DESCRIPTION
Hello,

I have received the following email from OVH and I suggest this pull request for the migration:

"Dear customer,

A few weeks ago, we notified you by email[1] that we are discontinuing v2 of the Keystone API on 24th March 2020. All users of the Keystone API must now use version 3, and make the changes required to do so.

Our last analysis shows that you are still using v2 of the API.

With most updates of this nature, you just need to modify the endpoint and the API version, but this change requires specific attention, which must be executed before 24th March 2020. Please update your tools or applications accordingly.

You can find more information on our status page[2].

Thank you once again for choosing OVHcloud.

The Public Cloud Team

[1] https://ovh.slgnt.eu/optiext/optiextension.dll?ID=dStdoW+qPGF+x+s02CEdQ_I66qw4G_Z_rqsNrzqCkOZiWQwdnmWGsZerWXZIQoWQpcyyq3Su3addd_
[2] http://travaux.ovh.net/?do=details&id=42179"